### PR TITLE
Add crawl limits and modernize UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,132 @@
-# Ignore Python virtual environment directory
-pdf_scraper_env/
-env/
-
-# Ignore the downloaded PDFs folder
-.pdf
-pdfs/
-
-# Ignore .env files (if you're using them for configuration)
-*.env
-
-# Ignore Python bytecode files
-*.pyc
-*.pyo
+# Byte-compiled / optimized / DLL files
 __pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# pyenv
+.python-version
+
+# pipenv
+Pipfile.lock
+
+# poetry
+poetry.lock
+
+# pdm
+pdm.lock
+
+# Environments
+.env
+.env.*
+venv/
+ENV/
+env/
+env.bak/
+venv.bak/
+.venv/
+.python-env/
+
+# Flask instance folder
+instance/
+
+# Flask uploads
+*.log
+
+# mypy
+.mypy_cache/
+.dmypy.json
+.dmypy/
+
+# Pyre type checker
+.pyre/
+
+# pytype
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# IDEs and editors
+.vscode/
+.idea/
+*.sublime-project
+*.sublime-workspace
+*.code-workspace
+*.sw[po]
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Windows
+Thumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+
+# Project-specific directories
+# Local folder where PDFs are stored after crawling
+/downloaded_pdfs/
+
+# ElasticSearch data dumps or scratch space
+/elasticsearch_index/*.json
+/elasticsearch_index/*.tmp
+
+# Local search index exports
+/elasticsearch_index/backups/
+
+# Temporary files
+*.tmp
+*.bak
+*.orig

--- a/app.py
+++ b/app.py
@@ -1,6 +1,8 @@
 import logging
 import os
+from datetime import datetime
 from pathlib import Path
+from typing import Any, Dict, Optional
 from urllib.parse import urlparse, urlunparse
 
 from flask import Flask, render_template, request
@@ -15,13 +17,34 @@ app = Flask(__name__)
 app.config["SECRET_KEY"] = os.getenv("FLASK_SECRET_KEY", "change-me")
 app.config["DOWNLOAD_DIR"] = Path(os.getenv("DOWNLOAD_DIR", "./downloaded_pdfs")).resolve()
 
-# Ensure the Elasticsearch index exists when the application starts
-create_index()
+ES_AVAILABLE = False
+try:
+    create_index()
+except RuntimeError as exc:
+    logger.warning("Elasticsearch unavailable at startup: %s", exc)
+else:
+    ES_AVAILABLE = True
+
+
+def _initial_context() -> Dict[str, Any]:
+    return {
+        "message": None,
+        "documents": [],
+        "error": None,
+        "indexing_error": None,
+    }
+
+
+def _store_context(context: Dict[str, Any]) -> Dict[str, Any]:
+    app.config["LAST_CONTEXT"] = context
+    return context
 
 
 @app.route("/")
 def index():
-    return render_template("index.html")
+    context = _initial_context()
+    context.update(app.config.get("LAST_CONTEXT", {}))
+    return render_template("index.html", **context)
 
 
 def _normalize_start_url(raw_url: str) -> str:
@@ -39,19 +62,74 @@ def _normalize_start_url(raw_url: str) -> str:
     return urlunparse(parsed)
 
 
+def _parse_limit(value: str, field_name: str) -> Optional[int]:
+    """Convert a form value into an optional positive integer."""
+
+    value = value.strip()
+    if not value:
+        return None
+
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be an integer") from exc
+
+    if parsed <= 0:
+        raise ValueError(f"{field_name} must be greater than 0")
+
+    return parsed
+
+
+def _format_downloaded_documents(documents: list) -> list:
+    formatted = []
+    for doc in documents:
+        path = Path(doc["path"])
+        size_kb = None
+        if path.exists():
+            size_kb = round(path.stat().st_size / 1024, 2)
+
+        downloaded_at = doc.get("downloaded_at")
+        readable_timestamp = downloaded_at
+        if downloaded_at:
+            try:
+                parsed = datetime.fromisoformat(downloaded_at.replace("Z", "+00:00"))
+                readable_timestamp = parsed.strftime("%Y-%m-%d %H:%M:%S %Z") or downloaded_at
+            except ValueError:
+                readable_timestamp = downloaded_at
+
+        formatted.append(
+            {
+                **doc,
+                "filename": path.name if path.name else doc.get("filename"),
+                "size_kb": size_kb,
+                "downloaded_display": readable_timestamp,
+            }
+        )
+
+    return formatted
+
+
 @app.post("/start_scraping")
 def start_scraping():
+    global ES_AVAILABLE
+
     website_url = request.form.get("url", "").strip()
     if not website_url:
-        return (
-            render_template("index.html", error="A website URL is required."),
-            400,
+        context = _store_context(
+            {
+                **_initial_context(),
+                "error": "A website URL is required.",
+            }
         )
+        return render_template("index.html", **context), 400
 
     try:
         start_url = _normalize_start_url(website_url)
+        max_pages = _parse_limit(request.form.get("max_pages", ""), "Maximum pages")
+        max_pdfs = _parse_limit(request.form.get("max_pdfs", ""), "Maximum PDFs")
     except ValueError as exc:
-        return render_template("index.html", error=str(exc)), 400
+        context = _store_context({**_initial_context(), "error": str(exc)})
+        return render_template("index.html", **context), 400
 
     download_folder: Path = app.config["DOWNLOAD_DIR"]
     download_folder.mkdir(parents=True, exist_ok=True)
@@ -62,24 +140,74 @@ def start_scraping():
         start_url,
         download_folder,
         allowed_hosts=allowed_hosts,
+        max_pages=max_pages,
+        max_pdfs=max_pdfs,
     )
-    indexed_count = index_multiple(downloaded_documents)
+    documents = _format_downloaded_documents(downloaded_documents)
+
+    indexing_error = None
+    indexed_count = 0
+
+    if documents:
+        if not ES_AVAILABLE:
+            try:
+                create_index()
+            except RuntimeError as exc:
+                indexing_error = f"Indexing skipped: {exc}"
+            else:
+                ES_AVAILABLE = True
+
+        if ES_AVAILABLE and indexing_error is None:
+            try:
+                indexed_count = index_multiple(downloaded_documents)
+            except RuntimeError as exc:
+                indexing_error = str(exc)
+                ES_AVAILABLE = False
 
     message = {
         "website_url": start_url,
         "downloaded": len(downloaded_documents),
         "indexed": indexed_count,
+        "max_pages": max_pages,
+        "max_pdfs": max_pdfs,
     }
 
-    return render_template("index.html", message=message)
+    context = _store_context(
+        {
+            "message": message,
+            "documents": documents,
+            "error": None,
+            "indexing_error": indexing_error,
+        }
+    )
+
+    return render_template("index.html", **context)
 
 
 @app.route("/search", methods=["GET", "POST"])
 def search():
+    global ES_AVAILABLE
     query = request.values.get("query", "").strip()
-    results = search_pdfs(query) if query else []
+    results = []
+    error = None
 
-    return render_template("search_results.html", query=query, results=results)
+    if query:
+        if not ES_AVAILABLE:
+            try:
+                create_index()
+            except RuntimeError as exc:
+                error = f"Search unavailable: {exc}"
+            else:
+                ES_AVAILABLE = True
+
+        if error is None:
+            try:
+                results = search_pdfs(query)
+            except RuntimeError as exc:
+                error = f"Search unavailable: {exc}"
+                ES_AVAILABLE = False
+
+    return render_template("search_results.html", query=query, results=results, error=error)
 
 
 if __name__ == "__main__":

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,0 +1,270 @@
+:root {
+    color-scheme: light dark;
+    font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    line-height: 1.5;
+    background-color: #f5f7fa;
+    color: #1d2433;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+a {
+    color: #1a5ad7;
+    text-decoration: none;
+}
+
+a:hover,
+a:focus {
+    text-decoration: underline;
+}
+
+body {
+    margin: 0;
+    background: linear-gradient(180deg, #f5f7fa 0%, #ffffff 100%);
+}
+
+.container {
+    width: min(960px, 90vw);
+    margin: 0 auto;
+    padding: 1.5rem 1rem;
+}
+
+.site-header {
+    background-color: #0d1b2a;
+    color: #ffffff;
+}
+
+.header-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.logo a {
+    color: inherit;
+    font-size: 1.5rem;
+    font-weight: 600;
+}
+
+.site-header nav a {
+    margin-left: 1rem;
+    font-weight: 500;
+}
+
+.site-footer {
+    background-color: #0d1b2a;
+    color: #ffffff;
+    padding: 1rem 0;
+    margin-top: 2rem;
+}
+
+.card {
+    background-color: #ffffff;
+    border-radius: 12px;
+    box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+    padding: 1.5rem;
+    margin-bottom: 1.5rem;
+}
+
+.form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1rem;
+    align-items: end;
+    margin-bottom: 1rem;
+}
+
+.form-inline {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-weight: 600;
+}
+
+input[type="text"],
+input[type="url"],
+input[type="number"],
+button {
+    width: 100%;
+    padding: 0.65rem 0.75rem;
+    border-radius: 8px;
+    border: 1px solid #cbd5f5;
+    font-size: 1rem;
+}
+
+button {
+    background-color: #1a5ad7;
+    color: #ffffff;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button.primary {
+    min-width: 180px;
+}
+
+button:hover:not([disabled]),
+button:focus-visible:not([disabled]) {
+    transform: translateY(-1px);
+    box-shadow: 0 8px 16px rgba(26, 90, 215, 0.25);
+}
+
+button[disabled] {
+    background-color: #93a3c8;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+.alert {
+    border-radius: 8px;
+    padding: 0.75rem 1rem;
+    margin: 1rem 0 0;
+    font-weight: 500;
+}
+
+.alert-error {
+    background-color: #fee2e2;
+    color: #991b1b;
+}
+
+.alert-warning {
+    background-color: #fef3c7;
+    color: #92400e;
+}
+
+.helper-text {
+    color: #4b5563;
+    margin-top: 0.5rem;
+    font-size: 0.95rem;
+}
+
+.summary-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+}
+
+.summary-list dt {
+    font-weight: 600;
+    color: #4b5563;
+}
+
+.summary-list dd {
+    margin: 0.25rem 0 0;
+    font-size: 1rem;
+}
+
+.table-wrapper {
+    overflow-x: auto;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+table th,
+table td {
+    text-align: left;
+    padding: 0.75rem;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+table tbody tr:hover {
+    background-color: #f1f5f9;
+}
+
+.results-list {
+    list-style: none;
+    padding: 0;
+    margin: 1.5rem 0 0;
+    display: grid;
+    gap: 1rem;
+}
+
+.result-item {
+    border-left: 4px solid #1a5ad7;
+    padding-left: 1rem;
+}
+
+.snippet {
+    margin: 0.5rem 0;
+    color: #1f2937;
+}
+
+.result-meta {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 0.5rem;
+    margin: 0;
+}
+
+.result-meta dt {
+    font-weight: 600;
+    color: #4b5563;
+}
+
+.result-meta dd {
+    margin: 0.25rem 0 0;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root {
+        background-color: #0f172a;
+        color: #e2e8f0;
+    }
+
+    body {
+        background: #0f172a;
+    }
+
+    .card {
+        background-color: #111c33;
+        box-shadow: none;
+    }
+
+    input[type="text"],
+    input[type="url"],
+    input[type="number"],
+    button {
+        background-color: #0f172a;
+        color: inherit;
+        border-color: #334155;
+    }
+
+    table tbody tr:hover {
+        background-color: #1f2937;
+    }
+
+    .alert-error {
+        background-color: rgba(239, 68, 68, 0.2);
+        color: #fecaca;
+    }
+
+    .alert-warning {
+        background-color: rgba(251, 191, 36, 0.2);
+        color: #fde68a;
+    }
+}

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -1,0 +1,14 @@
+document.addEventListener("DOMContentLoaded", () => {
+    const forms = document.querySelectorAll("form[data-loading]");
+
+    forms.forEach((form) => {
+        form.addEventListener("submit", () => {
+            const submitButton = form.querySelector("button[type='submit']");
+            if (submitButton) {
+                submitButton.disabled = true;
+                submitButton.dataset.originalText = submitButton.textContent;
+                submitButton.textContent = "Working…";
+            }
+        });
+    });
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}PDF Scraper{% endblock %}</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
+</head>
+<body>
+    <header class="site-header">
+        <div class="container header-content">
+            <h1 class="logo"><a href="/">PDF Scraper</a></h1>
+            <nav>
+                <a href="/">Home</a>
+                <a href="/search">Search</a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="container">
+        {% block content %}{% endblock %}
+    </main>
+
+    <footer class="site-footer">
+        <div class="container">
+            <p>Happy crawling! Provide a URL to discover and index PDFs automatically.</p>
+        </div>
+    </footer>
+
+    <script src="{{ url_for('static', filename='js/script.js') }}" defer></script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,40 +1,107 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>PDF Scraper</title>
-</head>
-<body>
-    <h1>Welcome to the PDF Scraper</h1>
+{% extends "base.html" %}
 
-    {% if error %}
-        <p style="color: red;">{{ error }}</p>
-    {% endif %}
+{% block title %}PDF Scraper - Crawl{% endblock %}
 
-    {% if message %}
-        <section>
-            <h2>Latest Crawl Summary</h2>
-            <p>Website: <strong>{{ message.website_url }}</strong></p>
-            <p>PDFs discovered: <strong>{{ message.downloaded }}</strong></p>
-            <p>PDFs indexed: <strong>{{ message.indexed }}</strong></p>
-        </section>
-        <hr>
-    {% endif %}
-
-    <form action="/start_scraping" method="POST">
-        <label for="url">Enter Website URL:</label>
-        <input type="text" id="url" name="url" placeholder="Enter the website URL" required>
-        <button type="submit">Start Scraping</button>
+{% block content %}
+<section class="card">
+    <h2>Start a Crawl</h2>
+    <p>Enter a starting URL and optional limits to keep the crawl focused on what matters.</p>
+    <form action="/start_scraping" method="POST" class="form-grid" data-loading>
+        <div class="form-group">
+            <label for="url">Website URL</label>
+            <input type="url" id="url" name="url" placeholder="https://example.com" required>
+        </div>
+        <div class="form-group">
+            <label for="max_pages">Maximum pages (optional)</label>
+            <input type="number" id="max_pages" name="max_pages" min="1" placeholder="e.g. 100">
+        </div>
+        <div class="form-group">
+            <label for="max_pdfs">Maximum PDFs (optional)</label>
+            <input type="number" id="max_pdfs" name="max_pdfs" min="1" placeholder="e.g. 50">
+        </div>
+        <button type="submit" class="primary">Start Scraping</button>
     </form>
 
-    <hr>
+    {% if error %}
+        <p class="alert alert-error">{{ error }}</p>
+    {% endif %}
 
-    <h2>Search for PDFs</h2>
-    <form action="/search" method="POST">
-        <label for="query">Search:</label>
+    {% if indexing_error %}
+        <p class="alert alert-warning">{{ indexing_error }}</p>
+    {% endif %}
+</section>
+
+{% if message %}
+<section class="card">
+    <h2>Latest Crawl Summary</h2>
+    <dl class="summary-list">
+        <div>
+            <dt>Website</dt>
+            <dd>{{ message.website_url }}</dd>
+        </div>
+        <div>
+            <dt>Pages limit</dt>
+            <dd>{{ message.max_pages if message.max_pages else 'No limit' }}</dd>
+        </div>
+        <div>
+            <dt>PDF limit</dt>
+            <dd>{{ message.max_pdfs if message.max_pdfs else 'No limit' }}</dd>
+        </div>
+        <div>
+            <dt>PDFs discovered</dt>
+            <dd>{{ message.downloaded }}</dd>
+        </div>
+        <div>
+            <dt>PDFs indexed</dt>
+            <dd>{{ message.indexed }}</dd>
+        </div>
+    </dl>
+</section>
+{% endif %}
+
+{% if documents %}
+<section class="card">
+    <h2>Downloaded PDFs</h2>
+    <div class="table-wrapper">
+        <table>
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Size (KB)</th>
+                    <th>Discovered on</th>
+                    <th>Downloaded at</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for doc in documents %}
+                <tr>
+                    <td>
+                        <a href="{{ doc.url }}" target="_blank" rel="noopener">{{ doc.filename }}</a>
+                    </td>
+                    <td>{% if doc.size_kb is not none %}{{ doc.size_kb }}{% else %}—{% endif %}</td>
+                    <td>
+                        {% if doc.source_page %}
+                            <a href="{{ doc.source_page }}" target="_blank" rel="noopener">Source page</a>
+                        {% else %}
+                            —
+                        {% endif %}
+                    </td>
+                    <td>{{ doc.downloaded_display or doc.downloaded_at }}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</section>
+{% endif %}
+
+<section class="card">
+    <h2>Search Indexed PDFs</h2>
+    <form action="/search" method="POST" class="form-inline" data-loading>
+        <label for="query" class="sr-only">Search query</label>
         <input type="text" id="query" name="query" placeholder="Enter keyword to search PDFs">
         <button type="submit">Search</button>
     </form>
-</body>
-</html>
+    <p class="helper-text">Search uses the text extracted during indexing. Ensure Elasticsearch is running.</p>
+</section>
+{% endblock %}

--- a/templates/search_results.html
+++ b/templates/search_results.html
@@ -1,43 +1,59 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Search Results</title>
-</head>
-<body>
-    <h1>Search Results</h1>
+{% extends "base.html" %}
+
+{% block title %}Search PDFs{% endblock %}
+
+{% block content %}
+<section class="card">
+    <h2>Search PDFs</h2>
+    <form action="/search" method="POST" class="form-inline" data-loading>
+        <label for="query" class="sr-only">Search query</label>
+        <input type="text" id="query" name="query" value="{{ query }}" placeholder="Enter keyword">
+        <button type="submit">Search</button>
+    </form>
+
+    {% if error %}
+        <p class="alert alert-error">{{ error }}</p>
+    {% endif %}
 
     {% if not query %}
-        <p>Please provide a search query.</p>
+        <p class="helper-text">Provide a query to search within the indexed PDF content.</p>
     {% elif results %}
-        <ul>
+        <ul class="results-list">
         {% for result in results %}
-            <li>
-                <a href="{{ result['_source']['url'] }}" target="_blank">{{ result['_source']['name'] }}</a>
+            <li class="result-item">
+                <h3>
+                    <a href="{{ result['_source']['url'] }}" target="_blank" rel="noopener">
+                        {{ result['_source']['name'] }}
+                    </a>
+                </h3>
                 {% set highlight = result.get('highlight', {}).get('content', []) %}
                 {% if highlight %}
-                    <p>{{ highlight[0]|safe }}</p>
+                    <p class="snippet">{{ highlight[0]|safe }}</p>
                 {% else %}
                     {% set snippet = result['_source']['content'][:200] %}
-                    <p>{{ snippet }}{% if result['_source']['content']|length > 200 %}...{% endif %}</p>
+                    <p class="snippet">{{ snippet }}{% if result['_source']['content']|length > 200 %}…{% endif %}</p>
                 {% endif %}
-                {% if result['_source'].get('source_page') %}
-                    <p>
-                        Found on:
-                        <a href="{{ result['_source']['source_page'] }}" target="_blank">
-                            {{ result['_source']['source_page'] }}
-                        </a>
-                    </p>
-                {% endif %}
+                <dl class="result-meta">
+                    {% if result['_source'].get('source_page') %}
+                        <div>
+                            <dt>Discovered on</dt>
+                            <dd>
+                                <a href="{{ result['_source']['source_page'] }}" target="_blank" rel="noopener">
+                                    {{ result['_source']['source_page'] }}
+                                </a>
+                            </dd>
+                        </div>
+                    {% endif %}
+                    <div>
+                        <dt>Indexed</dt>
+                        <dd>{{ result['_source']['downloaded_at'] }}</dd>
+                    </div>
+                </dl>
             </li>
         {% endfor %}
         </ul>
     {% else %}
         <p>No results found for <strong>{{ query }}</strong>.</p>
     {% endif %}
-
-    <hr>
-    <a href="/">Back to Homepage</a>
-</body>
-</html>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add optional crawl safety limits, duplicate download guardrails, and deterministic filenames when scraping PDFs
- improve Flask views with richer crawl summaries, formatted document metadata, and graceful Elasticsearch error handling
- refresh the interface with a shared layout, styled forms and tables, and small UX enhancements while keeping search discoverable

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d3bf834ac4832b80bb6e88641fb2ba